### PR TITLE
chore: support to auto set config for ts-monitor

### DIFF
--- a/pkg/cluster/spec/ts_meta.go
+++ b/pkg/cluster/spec/ts_meta.go
@@ -213,5 +213,11 @@ func (i *TSMetaInstance) SetDefaultConfig(instanceConf map[string]any) map[strin
 	}
 	instanceConf["gossip.members"] = metaGossipAddrs
 
+	// monitor
+	if i.topo.MonitoredOptions.TSMonitorEnabled {
+		instanceConf["monitor.pushers"] = "file"
+		instanceConf["monitor.store-enabled"] = true
+		instanceConf["monitor.store-path"] = filepath.Join(tsMetaSpec.LogDir, "metric", "meta-metric.data")
+	}
 	return instanceConf
 }

--- a/pkg/cluster/spec/ts_monitor.go
+++ b/pkg/cluster/spec/ts_monitor.go
@@ -317,12 +317,36 @@ func (i *TSMonitorInstance) SetDefaultConfig(instanceConf map[string]any, cluste
 		instanceConf = make(map[string]any, 20)
 	}
 
+	if !i.topo.MonitoredOptions.TSMonitorEnabled {
+		return instanceConf
+	}
+
+	// monitor
+	for _, server := range i.topo.TSMetaServers {
+		if i.Host == server.Host {
+			instanceConf["monitor.metric-path"] = filepath.Join(server.LogDir, "metric")
+			break
+		}
+	}
+	for _, server := range i.topo.TSStoreServers {
+		if i.Host == server.Host {
+			instanceConf["monitor.metric-path"] = filepath.Join(server.LogDir, "metric")
+			break
+		}
+	}
+	for _, server := range i.topo.TSStoreServers {
+		if i.Host == server.Host {
+			instanceConf["monitor.metric-path"] = filepath.Join(server.LogDir, "metric")
+			break
+		}
+	}
+
+	instanceConf["report.database"] = strings.Replace(clusterName, "-", "_", -1)
 	// TODO: report to monitor server address
 	if len(i.topo.TSSqlServers) > 0 {
 		instanceConf["report.address"] = fmt.Sprintf("%s:%d", i.topo.TSSqlServers[0].Host, i.topo.TSSqlServers[0].Port)
 	}
 
-	instanceConf["report.database"] = strings.Replace(clusterName, "-", "_", -1)
 	return instanceConf
 }
 

--- a/pkg/cluster/spec/ts_sql.go
+++ b/pkg/cluster/spec/ts_sql.go
@@ -199,5 +199,11 @@ func (i *TSSqlInstance) SetDefaultConfig(instanceConf map[string]any) map[string
 	instanceConf["http.flight-enabled"] = false // enabled at ts-data
 	instanceConf["logging.path"] = tsSqlSpec.LogDir
 
+	// monitor
+	if i.topo.MonitoredOptions.TSMonitorEnabled {
+		instanceConf["monitor.pushers"] = "file"
+		instanceConf["monitor.store-enabled"] = true
+		instanceConf["monitor.store-path"] = filepath.Join(tsSqlSpec.LogDir, "metric", "sql-metric.data")
+	}
 	return instanceConf
 }

--- a/pkg/cluster/spec/ts_store.go
+++ b/pkg/cluster/spec/ts_store.go
@@ -212,7 +212,7 @@ func (i *TSStoreInstance) SetDefaultConfig(instanceConf map[string]any) map[stri
 
 	instanceConf["gossip.bind-address"] = i.Host
 	instanceConf["gossip.store-bind-port"] = tsStoreSpec.GossipPort
-	instanceConf["gossip.meta-bind-port"] = tsStoreSpec.GossipPort - 1 // just for ts-store compatibility
+	instanceConf["gossip.meta-bind-port"] = tsStoreSpec.GossipPort - 1 // just for ts-meta compatibility
 
 	var metaGossipAddrs []string
 	for _, metaSpec := range i.topo.TSMetaServers {
@@ -220,5 +220,11 @@ func (i *TSStoreInstance) SetDefaultConfig(instanceConf map[string]any) map[stri
 	}
 	instanceConf["gossip.members"] = metaGossipAddrs
 
+	// monitor
+	if i.topo.MonitoredOptions.TSMonitorEnabled {
+		instanceConf["monitor.pushers"] = "file"
+		instanceConf["monitor.store-enabled"] = true
+		instanceConf["monitor.store-path"] = filepath.Join(tsStoreSpec.LogDir, "metric", "store-metric.data")
+	}
 	return instanceConf
 }


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close #54

### What is changed and how it works?

simplified startup monitoring capabilities

```yaml
monitored:
  ts_monitor_enabled: true

grafana_servers:
    - host: 127.0.0.1
```

### How Has This Been Tested?

- [x] test by manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
