### PR TITLE
fix: invalid deploy directory when install ts-store

### DIFF
--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -203,7 +203,7 @@ func setDefaultDir(parent, role, port string, field reflect.Value) {
 func getPort(v reflect.Value) string {
 	for i := 0; i < v.NumField(); i++ {
 		switch v.Type().Field(i).Name {
-		case "Port", "ClientPort":
+		case "Port", "ClientPort", "SelectPort":
 			return fmt.Sprintf("%d", v.Field(i).Int())
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close #56 

### What is changed and how it works?

```yaml
global:
  ......
  deploy_dir: "/tmp/gemini-deploy"

ts_store_servers:
  - host: 127.0.0.1
    select_port: 8401
```

The directories of ts-store will be:

```
Cluster name:    dev-cluster
Cluster version: v1.1.1
Role        Host       Ports                OS/Arch       Directories
----        ----       -----                -------       -----------
......
ts-store    127.0.0.1  8400/8401/8011       darwin/amd64  /tmp/gemini-deploy/ts-store-8401,... ⭐ 
```

### How Has This Been Tested?

- [x] full build
- [x] `gemix cluster install dev-cluster v1.1.1 ./min_new.yaml --skip-create-user -p` 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
